### PR TITLE
Fixes for WSL

### DIFF
--- a/pyocd_mpsse/mpsse_probe.py
+++ b/pyocd_mpsse/mpsse_probe.py
@@ -317,7 +317,7 @@ class FtdiMPSSE(object):
 		if (frequency > (60000000 // 2 // 65536) and self.divide_by_5_config(False)):
 			base_clock = 60000000
 		else:
-			_divide_by_5_config(self, True)
+			self.divide_by_5_config(self, True)
 			base_clock = 12000000
 
 		divisor = (base_clock // 2 + frequency - 1) // frequency - 1;

--- a/pyocd_mpsse/mpsse_probe.py
+++ b/pyocd_mpsse/mpsse_probe.py
@@ -160,6 +160,7 @@ class FtdiMPSSE(object):
 		self.purge()
 
 	def close(self):
+		util.dispose_resources(self._dev)
 		self._if = None
 		self._wr_ep = None
 		self._rd_ep = None

--- a/pyocd_mpsse/mpsse_probe.py
+++ b/pyocd_mpsse/mpsse_probe.py
@@ -33,6 +33,7 @@ from pyocd.core.options import OptionInfo
 from pyocd.core.plugin import Plugin
 from pyocd.utility.mask import parity32_high
 
+import sys
 LOG = logging.getLogger(__name__)
 #LOG.setLevel(logging.DEBUG)
 
@@ -108,6 +109,13 @@ class FtdiMPSSE(object):
 		if self._if is None:
 			raise exceptions.ProbeError()
 
+		# Fix device busy error on WSL (Windows subsystem for linux)
+		if (sys.platform.startswith('linux') and self._dev.is_kernel_driver_active(channel)):
+			try:
+				self._dev.detach_kernel_driver(channel)
+			except core.USBError as e:
+				raise exceptions.ProbeError("Could not detatch kernel driver from interface(%s): %s"%(channel, str(e)))
+	
 		device_types = {
 			0x500: ChipType.FT2232C,
 			0x700: ChipType.FT2232H,

--- a/pyocd_mpsse/mpsse_probe.py
+++ b/pyocd_mpsse/mpsse_probe.py
@@ -162,7 +162,28 @@ class FtdiMPSSE(object):
 		self.purge()
 
 	def close(self):
+		# Reset cmd to port
+		self._dev.ctrl_transfer(self.FTDI_DEVICE_OUT_REQTYPE,
+		                        self.SIO_RESET_REQUEST,
+								self.SIO_RESET_SIO,
+								self._if.bInterfaceNumber + 1)
+		# Clean tx and rx buffers
+		self.purge()
+	
+		# Release interface
+		self._dev._ctx.managed_release_interface(self._dev, self._if)
+		
+		# Reattach kernel driver
+		try:
+			self._dev.attach_kernel_driver(self._if.bInterfaceNumber)
+		except (NotImplementedError, core.USBError):
+			# Windows will cause not implemented error
+			pass
+		
+		# Release device it self
 		util.dispose_resources(self._dev)
+		
+		# Clean up other variables
 		self._if = None
 		self._wr_ep = None
 		self._rd_ep = None
@@ -443,17 +464,20 @@ class FindMPSSEProbe(object):
 		if (dev.idVendor, dev.idProduct) not in self.SUPPORTED_VIDS_PIDS:
 			return False
 
+		cfg = None
 		# Make sure the device has an active configuration
 		try:
 			# This can fail on Linux if the configuration is already active.
-			dev.set_configuration()
+			cfg = dev.get_active_configuration()
+			
 		except Exception:
 			# But do no act on possible errors, they'll be caught in the next try: clause
-			pass
+			cfg = None
 
 		try:
 			# This raises when no configuration is set
-			dev.get_active_configuration()
+			if cfg is None:
+				dev.set_configuration()
 
 			# Now read the serial. This will raise if there are access problems.
 			serial = dev.serial_number

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyocd-mpsse"
-version = "0.1.0"
+version = "0.1.1"
 description = "PyOCD debug probe plugin for the MPSSE mode of FTDI chips"
 authors = ["Andreas Fritiofson <andreas@fritiofson.net>"]
 license = "Apache-2.0"


### PR DESCRIPTION
While using WSL encountered issue with RESOURCE BUSY
It was fixed by unloading kernel driver. This had side effects when running same code multiple times there fore added more clean up on probe close to return into original state.

Also change handling of set_configuration() to be aligned to with recommended way in PYUSB project

Bumped version to know when these fixes are available on PIP