### PR TITLE
fix: add fallback value for probe serial

### DIFF
--- a/pyocd_mpsse/mpsse_probe.py
+++ b/pyocd_mpsse/mpsse_probe.py
@@ -78,9 +78,9 @@ class FtdiMPSSE(object):
 
 	def __init__(self, dev):
 		self._dev = dev
-		self._probe_id = dev.serial_number
-		self._vend = dev.manufacturer
-		self._prod = dev.product
+		self._probe_id = dev.serial_number or "Unknown Serial"
+		self._vend = dev.manufacturer or "Unknown Manufacturer"
+		self._prod = dev.product or "Unknown Product"
 		# USB interface and endpoints, will be assigned in open()
 		self._if = None
 		self._wr_ep = None


### PR DESCRIPTION
This commit prevent crashing when the probe does not have any serial pre-configured.

Before the fix:

```sh
pyocd list
0004651 C Error: can only concatenate str (not "NoneType") to str [__main__]
```

After the fix:

```sh
pyocd list
  #   Probe/Board          Unique ID        Target
----------------------------------------------------
  0   FTDI Quad RS232-HS   Unknown Serial   n/a
```